### PR TITLE
Make volume meter reflect levels of selected device

### DIFF
--- a/AudioLogger.Services/Device.cs
+++ b/AudioLogger.Services/Device.cs
@@ -1,20 +1,21 @@
+using NAudio.CoreAudioApi;
 using NAudio.Wave;
 
 namespace AudioLogger.Services
 {
     public class Device
     {
-        public Device(WaveInCapabilities capabilities, int deviceId, string productName = null)
+        public Device(string deviceId, string productName, bool loopback)
         {
-            Capabilities = capabilities;
             DeviceId = deviceId;
-            ProductName = productName ?? Capabilities.ProductName;
-        }
+            ProductName = productName;
+			isLoopback = loopback;
+		}
 
         public Device() {}
 
-        public WaveInCapabilities Capabilities { get; }
         public string ProductName { get; set; }
-        public int DeviceId { get; set; }
+        public string DeviceId { get; set; }
+		public bool isLoopback { get; }
     }
 }


### PR DESCRIPTION
Removed reliance on WaveIn device indices and using MMDevice for device
references. Now it should be possible to save selected MMDevice.ID in
config as more reliable device reference than WaveIn device index. Also,
solves truncated device names from WaveInCapabilities.ProductName.

Two more changes:
Perform input validation before disabling controls and correct RecordingDurationInMinutes validation.